### PR TITLE
fix: add parens to 0-arity function calls

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,13 +4,13 @@ defmodule Benchwarmer.Mixfile do
   def project do
     [
       app:          :benchwarmer,
-      version:      "0.0.2",
-      elixir:       "~> 1.0.0-rc1",
-      deps:         deps,
+      version:      "0.0.3",
+      elixir:       "~> 1.0",
+      deps:         deps(),
       name:         "Benchwarmer",
       source_url:   "https://github.com/mroth/benchwarmer",
-      description:  description,
-      package:      package
+      description:  description(),
+      package:      package()
     ]
   end
 


### PR DESCRIPTION
In Elixir 1.15, undefined variables are no longer converted into 0-arity function calls during compilation:

https://hexdocs.pm/elixir/1.15.7/changelog.html#potential-incompatibilities-1

> the behaviour where undefined variables were transformed into nullary function calls, often leading to confusing error reports, has been disabled during project compilation